### PR TITLE
Fix agent config injection

### DIFF
--- a/components/systems/agent/AgentControl.js
+++ b/components/systems/agent/AgentControl.js
@@ -27,7 +27,7 @@ export default function AgentControl({ data }) {
       rightSWR={commands}
       rightMenu={AgentCommandsList}
     >
-      <AgentPanel agentName={agentName} data={data} />
+      <AgentPanel data={data} />
     </PopoutDrawerWrapper>
   );
 }

--- a/components/systems/agent/AgentPanel.js
+++ b/components/systems/agent/AgentPanel.js
@@ -6,8 +6,9 @@ import AgentInstruct from "./tabs/AgentInstruct";
 import AgentAdmin from "./tabs/AgentAdmin";
 import AgentConfigure from "./tabs/AgentConfigure";
 import { useTheme } from "@mui/material/styles";
-export default function AgentPanel() {
+export default function AgentPanel({ data }) {
   const router = useRouter();
+  console.log("Agent config", data);
   console.log(router.query.config);
   const [tab, setTab] = useState(router.query.config == "true" ? 3 : 0);
   const handleTabChange = (event, newTab) => {
@@ -17,7 +18,7 @@ export default function AgentPanel() {
   const tabs = [
     <AgentChat key="chat" />,
     <AgentInstruct key="instruct" />,
-    <AgentConfigure key="admin" />,
+    <AgentConfigure key="config" data={data} />,
     <AgentAdmin key="admin" />,
   ];
   return (
@@ -33,8 +34,8 @@ export default function AgentPanel() {
       >
         <Tab label="Chat With Agent" />
         <Tab label="Instruct Agent" />
-        <Tab label="Configure Agent" />
-        <Tab label="Administrate Agent" />
+        <Tab label="Agent Settings" />
+        <Tab label="Modify Agent" />
       </Tabs>
       {tabs[tab]}
     </>

--- a/components/systems/agent/tabs/AgentConfigure.js
+++ b/components/systems/agent/tabs/AgentConfigure.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useMemo } from "react";
 import { useRouter } from "next/router";
 import { sdk } from "../../../../lib/apiClient";
 import useSWR from "swr";
@@ -17,15 +18,13 @@ import {
   FormControlLabel,
 } from "@mui/material";
 
-export default function AgentAdmin() {
-  const agentName = useRouter().query.agent;
+export default function AgentConfigure({ data }) {
   const [provider, setProvider] = useState(null);
   const [fields, setFields] = useState({});
   const [fieldValues, setFieldValues] = useState({});
   const [displayNames, setDisplayNames] = useState({});
-  const agentConfig = useSWR(`agent/${agentName}`, async () =>
-    sdk.getAgentConfig(agentName)
-  );
+  const router = useRouter();
+  const agentName = useMemo(() => router.query.agent, [router.query.agent]);
   const providers = useSWR("provider", async () => await sdk.getProviders());
   const extensionSettings = useSWR(
     `extensionSettings`,
@@ -134,17 +133,17 @@ export default function AgentAdmin() {
     mutate(`agent/${agentName}`);
   };
   useEffect(() => {
-    if (agentConfig.data?.settings?.provider) {
-      const currentProvider = agentConfig.data.settings.provider;
+    if (data?.settings?.provider) {
+      const currentProvider = data.settings.provider;
       setProvider(provider || currentProvider);
-      const currentSettings = { ...agentConfig.data.settings };
+      const currentSettings = { ...data.settings };
       delete currentSettings.provider;
       setFieldValues((prev) => ({
         ...prev,
         ...currentSettings,
       }));
     }
-  }, [agentConfig]);
+  }, [data]);
 
   useEffect(() => {
     if (provider !== null && providerSettings.data && extensionSettings.data) {

--- a/pages/agent/[agent].js
+++ b/pages/agent/[agent].js
@@ -1,11 +1,12 @@
 import { useRouter } from "next/router";
-import axios from "axios";
+import { useMemo } from "react";
 import useSWR from "swr";
 import AgentControl from "../../components/systems/agent/AgentControl";
 import ContentSWR from "../../components/data/ContentSWR";
 import { sdk } from "../../lib/apiClient";
 export default function Agent() {
-  const agentName = useRouter().query.agent;
+  const router = useRouter();
+  const agentName = useMemo(() => router.query.agent, [router.query.agent]);
   const agent = useSWR(
     `agent/${agentName}`,
     async () => await sdk.getAgentConfig(agentName)


### PR DESCRIPTION
Fix agent config injection
- It was doing multiple calls to pull agentConfig instead of just passing it from the agent page.  Fixed this.