### PR TITLE
Add download buttons in history

### DIFF
--- a/components/systems/conversation/ConversationHistory.js
+++ b/components/systems/conversation/ConversationHistory.js
@@ -6,6 +6,7 @@ import ReactMarkdown from "react-markdown";
 import { useTheme } from "@emotion/react";
 import { useState } from "react";
 import { ContentCopy as ContentCopyIcon } from "@mui/icons-material";
+import DownloadIcon from "@mui/icons-material/Download";
 import clipboardCopy from "clipboard-copy";
 export default function ConversationHistory({ chatHistory }) {
   const router = useRouter();
@@ -41,6 +42,100 @@ const ChatMessage = ({ chatItem }) => {
   const handleCopyClick = () => {
     clipboardCopy(formattedMessage);
   };
+  const handleDownloadClick = () => {
+    const element = document.createElement("a");
+    const file = new Blob([formattedMessage], {
+      type: "text/plain;charset=utf-8",
+    });
+    element.href = URL.createObjectURL(file);
+    element.download = `${chatItem.role}-${chatItem.timestamp}.txt`;
+    document.body.appendChild(element);
+    element.click();
+  };
+  const handleCopyCodeClick = () => {
+    const codeBlock = document.querySelector(".code-block");
+    const actualCode = codeBlock.querySelector("code");
+
+    clipboardCopy(actualCode.innerText);
+  };
+
+  const handleDownloadCodeClick = () => {
+    const codeBlock = document.querySelector(".code-block");
+    const actualCode = codeBlock.querySelector("code");
+    const lang = codeBlock.querySelector(".code-title")
+      ? codeBlock.querySelector(".code-title").innerText
+      : ""; // set default language if it's not defined
+
+    const langMap = {
+      "": "txt",
+      python: "py",
+      javascript: "js",
+      typescript: "ts",
+      html: "html",
+      css: "css",
+      json: "json",
+      yaml: "yaml",
+      markdown: "md",
+      shell: "sh",
+      bash: "sh",
+      sql: "sql",
+      java: "java",
+      c: "c",
+      cpp: "cpp",
+      csharp: "cs",
+      go: "go",
+      rust: "rs",
+      php: "php",
+      ruby: "rb",
+      perl: "pl",
+      lua: "lua",
+      r: "r",
+      swift: "swift",
+      kotlin: "kt",
+      scala: "scala",
+      clojure: "clj",
+      elixir: "ex",
+      erlang: "erl",
+      haskell: "hs",
+      ocaml: "ml",
+      pascal: "pas",
+      scheme: "scm",
+      coffeescript: "coffee",
+      fortran: "f",
+      julia: "jl",
+      lisp: "lisp",
+      prolog: "pro",
+      vbnet: "vb",
+      dart: "dart",
+      fsharp: "fs",
+      groovy: "groovy",
+      perl6: "pl",
+      powershell: "ps1",
+      puppet: "pp",
+      qml: "qml",
+      racket: "rkt",
+      sas: "sas",
+      verilog: "v",
+      vhdl: "vhd",
+      apex: "cls",
+      matlab: "m",
+      nim: "nim",
+      ocaml: "ml",
+      pascal: "pas",
+      scheme: "scm",
+      coffeescript: "coffee",
+    };
+    const element = document.createElement("a");
+    const file = new Blob([actualCode.innerText], {
+      type: "text/plain;charset=utf-8",
+    });
+    element.href = URL.createObjectURL(file);
+    element.download = `${chatItem.role}-${chatItem.timestamp}.${
+      langMap[lang] || "txt"
+    }`; // default to .txt if language not found
+    document.body.appendChild(element);
+    element.click();
+  };
   return (
     <Box
       sx={{
@@ -74,8 +169,11 @@ const ChatMessage = ({ chatItem }) => {
                         {language && (
                           <div className="code-title">{language}</div>
                         )}
-                        <IconButton onClick={handleCopyClick}>
+                        <IconButton onClick={handleCopyCodeClick}>
                           <ContentCopyIcon />
+                        </IconButton>
+                        <IconButton onClick={handleDownloadCodeClick}>
+                          <DownloadIcon />
                         </IconButton>
                         <code className={"code-block"} {...props}>
                           {children}
@@ -114,6 +212,9 @@ const ChatMessage = ({ chatItem }) => {
             </IconButton>
             <IconButton onClick={handleCopyClick}>
               <ContentCopyIcon />
+            </IconButton>
+            <IconButton onClick={handleDownloadClick}>
+              <DownloadIcon />
             </IconButton>
           </>
         )}


### PR DESCRIPTION
Add download buttons in history
- You can either download a whole message or download individual code blocks.
- Downloading a code block will save it as the extension for the language the code block was intended for.

![image](https://github.com/AGiXT/nextjs/assets/102809327/d0fa15ff-ef0a-4156-83f8-742f94ece9c4)

![image](https://github.com/AGiXT/nextjs/assets/102809327/f9e0dbcb-62bf-40a9-940f-c2e2cefee9b0)

