### PR TITLE
Fix getCookie result

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -342,8 +342,10 @@ App.propTypes = {
 };
 
 App.getInitialProps = async ({ ctx }) => {
+  let dark = getCookie("dark", ctx);
+  dark === "true" ? (dark = true) :  dark === "false" ? (dark = false) : (dark = null);
   return { 
-    dark: true,
+    dark: dark,
     pageProps: {},
   };
 };


### PR DESCRIPTION
Added an line of logic to ensure the getCookie return value is properly added to the dark state 

# Description

reassignment of dark value to its true boolean value

## Motivation and Context

Ensures the cookie value is added 

## How has this been tested?

toggled darkMode then reloaded page and confirms it stays dark 
toggled darkMode to false reloaded page and confirms it stays light 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Changes visible to users:

- [X] **Bug fix** (prefix: `fix` - non-breaking change which fixes an issue)
- [ ] **New feature** (prefix: `feat` - non-breaking change which adds functionality)
- [ ] **Breaking change** (prefix: `feat!!` or `fix!!` - fix or feature that would cause existing functionality to not work as expected)

Internal changes:

- [ ] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [ ] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [X] My code follows the code style of this project and passes `yarn run lint`.
- [ ] My change requires a change to the documentation.
- [X] My change works!
